### PR TITLE
Fixes getting URL of cameras with empty paths

### DIFF
--- a/CAM2ImageArchiver/CAM2ImageArchiver.py
+++ b/CAM2ImageArchiver/CAM2ImageArchiver.py
@@ -20,7 +20,7 @@ import time
 import csv
 import os
 
-from .utils import check_file_exists, check_result_path_writable
+from .utils import *
 from .camera import *
 from .CameraHandler import CameraHandler
 from .error import ExpectedCAM2APIClientCameraObject

--- a/CAM2ImageArchiver/camera.py
+++ b/CAM2ImageArchiver/camera.py
@@ -318,8 +318,12 @@ class IPCamera(Camera):
         if self.port in ('', None):
             url = 'http://{}{}'.format(self.ip, path)
         else:
-            url = 'http://{}:{}{}'.format(
-                self.ip, self.port, path)
+            if path is not None:
+                url = 'http://{}:{}{}'.format(
+                    self.ip, self.port, path)
+            else:
+                url = 'http://{}:{}'.format(
+                    self.ip, self.port)
 
         return url
 


### PR DESCRIPTION
Current version was appending "None" to cameras with no path.