### PR TITLE
Fix get_url when the path is None

### DIFF
--- a/CAM2ImageArchiver/camera.py
+++ b/CAM2ImageArchiver/camera.py
@@ -318,8 +318,12 @@ class IPCamera(Camera):
         if self.port in ('', None):
             url = 'http://{}{}'.format(self.ip, path)
         else:
-            url = 'http://{}:{}{}'.format(
-                self.ip, self.port, path)
+            if path is None:
+                url = 'http://{}:{}'.format(
+                    self.ip, self.port)
+            else:
+                url = 'http://{}:{}{}'.format(
+                    self.ip, self.port, path)
 
         return url
 


### PR DESCRIPTION
Current version appends None to the port when the path of a camera is None